### PR TITLE
Ghosts get notified of player energiser usage

### DIFF
--- a/PacmanGame(WinForms)/Controller.cs
+++ b/PacmanGame(WinForms)/Controller.cs
@@ -27,11 +27,30 @@ namespace PacmanGame_WinForms_
         {
             return SingletonHolder.instance;
         }
+        private List<IEnergiserObserver> EnergiserObservers = new List<IEnergiserObserver>();
 
         public int MapHeight = Game.Field.Rows;
         public int MapWidth = Game.Field.Columns;
 
         public int LevelMax = Game.MaxLevel;
+
+        public void AttachEnergiserObserver(IEnergiserObserver observer)
+        {
+            EnergiserObservers.Add(observer);
+        }
+
+        public void DetachEnergiserObserver(IEnergiserObserver observer)
+        {
+            EnergiserObservers.Remove(observer);
+        }
+
+        public void NotifyEnergiserObservers()
+        {
+            foreach (var observer in EnergiserObservers)
+            {
+                observer.Update();
+            }
+        }
 
         public Vector2 GetPacmanPos()
         {
@@ -66,11 +85,6 @@ namespace PacmanGame_WinForms_
         public bool PacmanEatBonus(int x, int y)
         {
             return x == Game.Pacman.X && y == Game.Pacman.Y;
-        }
-
-        public bool EnergActive()
-        {
-            return Game.Energisers.Count > 0;
         }
 
         public bool CheckFieldLimit(int y, int x)
@@ -159,6 +173,11 @@ namespace PacmanGame_WinForms_
             if (matrix[y, x] is Energiser)
             {               
                 Game.Energisers.Add(new Energiser(x, y, Game.TimeEnergiserActive));
+
+                // No active energisers before, ghosts stop chasing
+                if (Game.Energisers.Count == 1)
+                    Controller.GetInstance().NotifyEnergiserObservers();
+
                 return true;
             }
 

--- a/PacmanGame(WinForms)/Forms/Game.cs
+++ b/PacmanGame(WinForms)/Forms/Game.cs
@@ -79,6 +79,10 @@ namespace PacmanGame_WinForms_
         {
             Field = new Field();
             GhostTeam = new GhostTeam();
+            foreach (var ghost in GhostTeam.List)
+            {
+                Controller.GetInstance().AttachEnergiserObserver(ghost);
+            }
 
             PlusLiveBonus   = pliusbonusFactory.GetBonus("Live");
             DoubleCoinBonus = pliusbonusFactory.GetBonus("Double");
@@ -219,7 +223,7 @@ namespace PacmanGame_WinForms_
         void GhostMoving(int index)
         {
             GhostTeam[index].Move();
-            GhostTeam[index].CheckEnergizerActive();
+            GhostTeam[index].ChooseBehaviour();
             RemoveEnergiser();
 
             Interface.UpdateEnemy(GhostTeam[index], index);
@@ -436,6 +440,7 @@ namespace PacmanGame_WinForms_
 
         void RemoveEnergiser()
         {
+            bool activeEnergiserExisted = Game.Energisers.Count > 0;
             for (int i = 0; i < Energisers.Count; ++i)
             {
                 if (Energisers[i].ReadyToStop(Energisers[i].Time))
@@ -443,6 +448,9 @@ namespace PacmanGame_WinForms_
                     Energisers.RemoveAt(i);
                 }
             }
+            // No active energisers left after removal, ghosts start chasing
+            if (activeEnergiserExisted && Game.Energisers.Count == 0)
+                Controller.GetInstance().NotifyEnergiserObservers();
         }
 
         private void SetGameField()

--- a/PacmanGame(WinForms)/Ghosts/Ghost.cs
+++ b/PacmanGame(WinForms)/Ghosts/Ghost.cs
@@ -8,7 +8,7 @@ using System.Timers;
 
 namespace PacmanGame_WinForms_
 {
-    public abstract class Ghost : BasePoint
+    public abstract class Ghost : BasePoint, IEnergiserObserver
     {
         public bool passive = false;
         public bool _isEmpty = false;
@@ -17,7 +17,8 @@ namespace PacmanGame_WinForms_
         public const int ReadyRespaun = 10;
         public int Wait = 0;
         private readonly int respaunX;
-        private readonly int respaunY;     
+        private readonly int respaunY;
+        private bool energiserActive = false;
 
         public Ghost() : base()
         {
@@ -91,9 +92,9 @@ namespace PacmanGame_WinForms_
             }
         }
 
-        public void CheckEnergizerActive()
+        public void ChooseBehaviour()
         { 
-            if (Controller.GetInstance().EnergActive())
+            if (energiserActive)
             {
                 Image = Properties.Resources.GrayGhost;               
                 ChangeInterval();
@@ -362,6 +363,11 @@ namespace PacmanGame_WinForms_
         public bool CheckWall(int y, int x)
         {
             return Controller.GetInstance().GhostCheckWall(y, x);
+        }
+
+        public void Update()
+        {
+            energiserActive = !energiserActive;
         }
     }  
 }

--- a/PacmanGame(WinForms)/IEnergiserObserver.cs
+++ b/PacmanGame(WinForms)/IEnergiserObserver.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PacmanGame_WinForms_
+{
+    internal interface IEnergiserObserver
+    {
+        void Update();
+    }
+}


### PR DESCRIPTION
Instead of checking for active energisers in controller, ghosts contain active energiser state internally. 
Energiser state is updated in two cases:
a) When the player collects an energiser and the previous active energiser count was 0 (state changes to true);
b) When the last active energiser's timer runs out and it is destroyed (state changes to false).
The list of objects to notify (observers) is stored in the Controller singleton instance. The list is filled with ghost objects from the GhostTeam object (in Game.cs) after it is created.